### PR TITLE
Ensure failed results always have a Problem

### DIFF
--- a/ManagedCode.Communication.AspNetCore/WebApi/Extensions/ControllerExtensions.cs
+++ b/ManagedCode.Communication.AspNetCore/WebApi/Extensions/ControllerExtensions.cs
@@ -10,7 +10,7 @@ public static class ControllerExtensions
         if (result.IsSuccess)
             return new OkObjectResult(result.Value);
         
-        var problem = result.Problem ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
+        var problem = result.GetProblemNoFallback() ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
         return new ObjectResult(problem)
         {
             StatusCode = problem.StatusCode
@@ -22,7 +22,7 @@ public static class ControllerExtensions
         if (result.IsSuccess)
             return new NoContentResult();
         
-        var problem = result.Problem ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
+        var problem = result.GetProblemNoFallback() ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
         return new ObjectResult(problem)
         {
             StatusCode = problem.StatusCode
@@ -34,7 +34,7 @@ public static class ControllerExtensions
         if (result.IsSuccess)
             return Results.Ok(result.Value);
         
-        var problem = result.Problem ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
+        var problem = result.GetProblemNoFallback() ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
         return Results.Problem(
             title: problem.Title,
             detail: problem.Detail,
@@ -50,7 +50,7 @@ public static class ControllerExtensions
         if (result.IsSuccess)
             return Results.NoContent();
         
-        var problem = result.Problem ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
+        var problem = result.GetProblemNoFallback() ?? Problem.Create("Operation failed", "Unknown error occurred", 500);
         return Results.Problem(
             title: problem.Title,
             detail: problem.Detail,

--- a/ManagedCode.Communication.Orleans/Converters/CollectionResultTSurrogateConverter.cs
+++ b/ManagedCode.Communication.Orleans/Converters/CollectionResultTSurrogateConverter.cs
@@ -9,8 +9,10 @@ public sealed class CollectionResultTSurrogateConverter<T> : IConverter<Collecti
 {
     public CollectionResult<T> ConvertFromSurrogate(in CollectionResultTSurrogate<T> surrogate)
     {
-        return CollectionResult<T>.Create(surrogate.IsSuccess, surrogate.Collection, surrogate.PageNumber, surrogate.PageSize, surrogate.TotalItems,
-            surrogate.Problem);
+        if (surrogate.IsSuccess)
+            return CollectionResult<T>.CreateSuccess(surrogate.Collection, surrogate.PageNumber, surrogate.PageSize, surrogate.TotalItems);
+
+        return CollectionResult<T>.CreateFailed(surrogate.Problem ?? Problem.GenericError(), surrogate.Collection);
     }
 
     public CollectionResultTSurrogate<T> ConvertToSurrogate(in CollectionResult<T> value)

--- a/ManagedCode.Communication.Orleans/Converters/ResultSurrogateConverter.cs
+++ b/ManagedCode.Communication.Orleans/Converters/ResultSurrogateConverter.cs
@@ -8,7 +8,10 @@ public sealed class ResultSurrogateConverter : IConverter<Result, ResultSurrogat
 {
     public Result ConvertFromSurrogate(in ResultSurrogate surrogate)
     {
-        return Result.Create(surrogate.IsSuccess, surrogate.Problem);
+        if (surrogate.IsSuccess)
+            return Result.Succeed();
+
+        return Result.CreateFailed(surrogate.Problem ?? Problem.GenericError());
     }
 
     public ResultSurrogate ConvertToSurrogate(in Result value)

--- a/ManagedCode.Communication.Orleans/Converters/ResultTSurrogateConverter.cs
+++ b/ManagedCode.Communication.Orleans/Converters/ResultTSurrogateConverter.cs
@@ -8,7 +8,10 @@ public sealed class ResultTSurrogateConverter<T> : IConverter<Result<T>, ResultT
 {
     public Result<T> ConvertFromSurrogate(in ResultTSurrogate<T> surrogate)
     {
-        return Result<T>.Create(surrogate.IsSuccess, surrogate.Value, surrogate.Problem);
+        if (surrogate.IsSuccess)
+            return Result<T>.Succeed(surrogate.Value!);
+
+        return Result<T>.CreateFailed(surrogate.Problem ?? Problem.GenericError(), surrogate.Value);
     }
 
     public ResultTSurrogate<T> ConvertToSurrogate(in Result<T> value)

--- a/ManagedCode.Communication.Tests/AspNetCore/Extensions/ControllerExtensionsTests.cs
+++ b/ManagedCode.Communication.Tests/AspNetCore/Extensions/ControllerExtensionsTests.cs
@@ -86,7 +86,7 @@ public class ControllerExtensionsTests
     public void ToActionResult_WithNoProblem_ReturnsDefaultError()
     {
         // Arrange - manually create failed result without problem
-        var result = new Result<string> { IsSuccess = false, Problem = null };
+        var result = (Result<string>)default;
 
         // Act
         var actionResult = result.ToActionResult();

--- a/ManagedCode.Communication.Tests/CollectionResults/CollectionResultFailMethodsTests.cs
+++ b/ManagedCode.Communication.Tests/CollectionResults/CollectionResultFailMethodsTests.cs
@@ -28,7 +28,7 @@ public class CollectionResultFailMethodsTests
         result.PageSize.Should().Be(0);
         result.TotalItems.Should().Be(0);
         result.TotalPages.Should().Be(0);
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion
@@ -48,7 +48,7 @@ public class CollectionResultFailMethodsTests
         result.IsFailed.Should().BeTrue();
         result.Collection.Should().BeEquivalentTo(items);
         result.Collection.Should().HaveCount(5);
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class CollectionResultFailMethodsTests
         result.IsFailed.Should().BeTrue();
         result.Collection.Should().BeEquivalentTo(items);
         result.Collection.Should().HaveCount(3);
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     [Fact]

--- a/ManagedCode.Communication.Tests/CollectionResults/CollectionResultFromMethodsTests.cs
+++ b/ManagedCode.Communication.Tests/CollectionResults/CollectionResultFromMethodsTests.cs
@@ -460,7 +460,7 @@ public class CollectionResultFromMethodsTests
 
         // Assert
         result.IsFailed.Should().BeTrue();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion
@@ -507,7 +507,7 @@ public class CollectionResultFromMethodsTests
 
         // Assert
         result.IsFailed.Should().BeTrue();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion

--- a/ManagedCode.Communication.Tests/Extensions/ProblemExtensionsTests.cs
+++ b/ManagedCode.Communication.Tests/Extensions/ProblemExtensionsTests.cs
@@ -294,8 +294,8 @@ public class ProblemExtensionsTests
         var problem = new Problem();
 
         // Act
-        problem.AddInvalidMessage("email", "Email is required");
-        problem.AddInvalidMessage("email", "Email format is invalid");
+        problem.AddValidationError("email", "Email is required");
+        problem.AddValidationError("email", "Email format is invalid");
 
         // Assert
         problem.InvalidField("email")
@@ -315,7 +315,7 @@ public class ProblemExtensionsTests
         var problem = new Problem();
 
         // Act
-        problem.AddInvalidMessage("General error occurred");
+        problem.AddValidationError("General error occurred");
 
         // Assert
         problem.InvalidField("_general")

--- a/ManagedCode.Communication.Tests/Extensions/ProblemExtensionsTests.cs
+++ b/ManagedCode.Communication.Tests/Extensions/ProblemExtensionsTests.cs
@@ -286,4 +286,43 @@ public class ProblemExtensionsTests
         errors["email"].Should().Contain("Already exists");
         errors["password"].Should().Contain("Too short");
     }
+
+    [Fact]
+    public void AddInvalidMessage_ShouldAddValidationError()
+    {
+        // Arrange
+        var problem = new Problem();
+
+        // Act
+        problem.AddInvalidMessage("email", "Email is required");
+        problem.AddInvalidMessage("email", "Email format is invalid");
+
+        // Assert
+        problem.InvalidField("email")
+            .Should()
+            .BeTrue();
+        var emailErrors = problem.InvalidFieldError("email");
+        emailErrors.Should()
+            .Contain("Email is required");
+        emailErrors.Should()
+            .Contain("Email format is invalid");
+    }
+
+    [Fact]
+    public void AddInvalidMessage_WithGeneralMessage_ShouldAddToGeneralErrors()
+    {
+        // Arrange
+        var problem = new Problem();
+
+        // Act
+        problem.AddInvalidMessage("General error occurred");
+
+        // Assert
+        problem.InvalidField("_general")
+            .Should()
+            .BeTrue();
+        var generalErrors = problem.InvalidFieldError("_general");
+        generalErrors.Should()
+            .Be("General error occurred");
+    }
 }

--- a/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
+++ b/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
@@ -293,69 +293,6 @@ public class CollectionResultTests
     }
 
     [Fact]
-    public void AddInvalidMessage_ShouldAddValidationError()
-    {
-        // Arrange
-        var result = CollectionResult<string>.Invalid();
-
-        // Act
-        result.AddInvalidMessage("email", "Email is required");
-        result.AddInvalidMessage("email", "Email format is invalid");
-
-        // Assert
-        result.InvalidField("email")
-            .Should()
-            .BeTrue();
-        var emailErrors = result.InvalidFieldError("email");
-        emailErrors.Should()
-            .Contain("Email is required");
-        emailErrors.Should()
-            .Contain("Email format is invalid");
-    }
-
-    [Fact]
-    public void AddInvalidMessage_WithGeneralMessage_ShouldAddToGeneralErrors()
-    {
-        // Arrange
-        var result = CollectionResult<string>.Invalid();
-
-        // Act
-        result.AddInvalidMessage("General error occurred");
-
-        // Assert
-        result.InvalidField("_general")
-            .Should()
-            .BeTrue();
-        var generalErrors = result.InvalidFieldError("_general");
-        generalErrors.Should()
-            .Be("General error occurred");
-    }
-
-    [Fact]
-    public void AddInvalidMessage_ThrowsOnSuccessfulResult()
-    {
-        // Arrange
-        var result = CollectionResult<string>.Empty();
-
-        // Act & Assert
-        result.Invoking(r => r.AddInvalidMessage("email", "Email is required"))
-            .Should()
-            .ThrowExactly<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void AddInvalidMessage_WithGeneralMessage_ThrowsOnSuccessfulResult()
-    {
-        // Arrange
-        var result = CollectionResult<string>.Empty();
-
-        // Act & Assert
-        result.Invoking(r => r.AddInvalidMessage("General error occurred"))
-            .Should()
-            .ThrowExactly<InvalidOperationException>();
-    }
-
-    [Fact]
     public void ThrowIfFail_WithSuccessfulResult_ShouldNotThrow()
     {
         // Arrange

--- a/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
+++ b/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
@@ -296,7 +296,7 @@ public class CollectionResultTests
     public void AddInvalidMessage_ShouldAddValidationError()
     {
         // Arrange
-        var result = CollectionResult<string>.Empty();
+        var result = CollectionResult<string>.Invalid();
 
         // Act
         result.AddInvalidMessage("email", "Email is required");
@@ -317,7 +317,7 @@ public class CollectionResultTests
     public void AddInvalidMessage_WithGeneralMessage_ShouldAddToGeneralErrors()
     {
         // Arrange
-        var result = CollectionResult<string>.Empty();
+        var result = CollectionResult<string>.Invalid();
 
         // Act
         result.AddInvalidMessage("General error occurred");

--- a/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
+++ b/ManagedCode.Communication.Tests/Results/CollectionResultTests.cs
@@ -332,6 +332,30 @@ public class CollectionResultTests
     }
 
     [Fact]
+    public void AddInvalidMessage_ThrowsOnSuccessfulResult()
+    {
+        // Arrange
+        var result = CollectionResult<string>.Empty();
+
+        // Act & Assert
+        result.Invoking(r => r.AddInvalidMessage("email", "Email is required"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AddInvalidMessage_WithGeneralMessage_ThrowsOnSuccessfulResult()
+    {
+        // Arrange
+        var result = CollectionResult<string>.Empty();
+
+        // Act & Assert
+        result.Invoking(r => r.AddInvalidMessage("General error occurred"))
+            .Should()
+            .ThrowExactly<InvalidOperationException>();
+    }
+
+    [Fact]
     public void ThrowIfFail_WithSuccessfulResult_ShouldNotThrow()
     {
         // Arrange

--- a/ManagedCode.Communication.Tests/Results/ResultFailMethodsTests.cs
+++ b/ManagedCode.Communication.Tests/Results/ResultFailMethodsTests.cs
@@ -20,7 +20,7 @@ public class ResultFailMethodsTests
         // Assert
         result.IsFailed.Should().BeTrue();
         result.IsSuccess.Should().BeFalse();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion

--- a/ManagedCode.Communication.Tests/Results/ResultStaticHelperMethodsTests.cs
+++ b/ManagedCode.Communication.Tests/Results/ResultStaticHelperMethodsTests.cs
@@ -22,7 +22,7 @@ public class ResultStaticHelperMethodsTests
         result.IsFailed.Should().BeTrue();
         result.IsSuccess.Should().BeFalse();
         result.Value.Should().BeNull();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     [Fact]

--- a/ManagedCode.Communication.Tests/Results/ResultTFailMethodsTests.cs
+++ b/ManagedCode.Communication.Tests/Results/ResultTFailMethodsTests.cs
@@ -22,7 +22,7 @@ public class ResultTFailMethodsTests
         result.IsFailed.Should().BeTrue();
         result.IsSuccess.Should().BeFalse();
         result.Value.Should().BeNull();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion
@@ -41,7 +41,7 @@ public class ResultTFailMethodsTests
         // Assert
         result.IsFailed.Should().BeTrue();
         result.Value.Should().Be(value);
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class ResultTFailMethodsTests
         // Assert
         result.IsFailed.Should().BeTrue();
         result.Value.Should().BeNull();
-        result.HasProblem.Should().BeFalse();
+        result.HasProblem.Should().BeTrue();
     }
 
     #endregion

--- a/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
@@ -46,7 +46,7 @@ public partial struct CollectionResult<T> : IResult
     public bool IsSuccess { get; set; }
 
     [JsonIgnore]
-    public bool IsFailed => !IsSuccess || HasProblem;
+    public bool IsFailed => !IsSuccess;
 
     [JsonPropertyName("collection")]
     [JsonPropertyOrder(2)]
@@ -69,10 +69,22 @@ public partial struct CollectionResult<T> : IResult
     [JsonPropertyOrder(6)]
     public int TotalPages { get; set; }
 
+    private Problem? _problem;
+
     [JsonPropertyName("problem")]
     [JsonPropertyOrder(7)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Problem? Problem { get; set; }
+    public Problem? Problem
+    {
+        get
+        {
+            if (_problem is null && !IsSuccess)
+                _problem = Problem.GenericError();
+
+            return _problem;
+        }
+        private init => _problem = value;
+    }
 
     [JsonIgnore]
     public bool IsEmpty => Collection is null || Collection.Length == 0;
@@ -82,15 +94,22 @@ public partial struct CollectionResult<T> : IResult
 
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(Problem))]
-    public bool HasProblem => Problem != null;
+    public bool HasProblem => !IsSuccess;
 
     #region IResultProblem Implementation
 
+    /// <summary>
+    ///     Get the Problem assigned to the result without falling back to a generic error if no problem is assigned.
+    ///     Useful if a different default problem is desired.
+    /// </summary>
+    internal Problem? GetProblemNoFallback() => _problem;
+
     public bool ThrowIfFail()
     {
-        if (HasProblem)
+        var problem = Problem;
+        if (problem is not null)
         {
-            throw Problem;
+            throw problem;
         }
 
         return false;
@@ -100,7 +119,7 @@ public partial struct CollectionResult<T> : IResult
     public bool TryGetProblem([MaybeNullWhen(false)] out Problem problem)
     {
         problem = Problem;
-        return HasProblem;
+        return problem is not null;
     }
 
     #endregion
@@ -125,44 +144,38 @@ public partial struct CollectionResult<T> : IResult
 
     public void AddInvalidMessage(string message)
     {
-        if (Problem == null)
-        {
-            Problem = Problem.Validation((ProblemConstants.ValidationFields.General, message));
-        }
-        else
-        {
-            Problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-            if (Problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-            {
-                if (!errors.ContainsKey(ProblemConstants.ValidationFields.General))
-                {
-                    errors[ProblemConstants.ValidationFields.General] = new List<string>();
-                }
+        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
 
-                errors[ProblemConstants.ValidationFields.General]
-                    .Add(message);
+        var problem = Problem;
+
+        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
+        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
+        {
+            if (!errors.ContainsKey(ProblemConstants.ValidationFields.General))
+            {
+                errors[ProblemConstants.ValidationFields.General] = new List<string>();
             }
+
+            errors[ProblemConstants.ValidationFields.General]
+                .Add(message);
         }
     }
 
     public void AddInvalidMessage(string key, string value)
     {
-        if (Problem == null)
-        {
-            Problem = Problem.Validation((key, value));
-        }
-        else
-        {
-            Problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-            if (Problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-            {
-                if (!errors.ContainsKey(key))
-                {
-                    errors[key] = new List<string>();
-                }
+        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
 
-                errors[key].Add(value);
+        var problem = Problem;
+
+        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
+        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
+        {
+            if (!errors.ContainsKey(key))
+            {
+                errors[key] = new List<string>();
             }
+
+            errors[key].Add(value);
         }
     }
 

--- a/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
@@ -135,51 +135,28 @@ public partial struct CollectionResult<T> : IResult
 
     public bool InvalidField(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.ContainsKey(fieldName) ?? false;
+        return !IsSuccess && Problem.InvalidField(fieldName);
     }
 
     public string InvalidFieldError(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.TryGetValue(fieldName, out var fieldErrors) == true ? string.Join(", ", fieldErrors) : string.Empty;
+        return IsSuccess
+            ? string.Empty
+            : Problem.InvalidFieldError(fieldName);
     }
 
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string message)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(ProblemConstants.ValidationFields.General))
-            {
-                errors[ProblemConstants.ValidationFields.General] = new List<string>();
-            }
-
-            errors[ProblemConstants.ValidationFields.General]
-                .Add(message);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(message);
     }
 
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string key, string value)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(key))
-            {
-                errors[key] = new List<string>();
-            }
-
-            errors[key].Add(value);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(key, value);
     }
 
     #endregion

--- a/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
@@ -18,7 +18,7 @@ public partial struct CollectionResult<T> : IResult
     {
     }
 
-    internal CollectionResult(bool isSuccess, T[]? collection, int pageNumber, int pageSize, int totalItems, Problem? problem = null)
+    private CollectionResult(bool isSuccess, T[]? collection, int pageNumber, int pageSize, int totalItems, Problem? problem = null)
     {
         IsSuccess = isSuccess;
         Collection = collection ?? [];
@@ -29,9 +29,14 @@ public partial struct CollectionResult<T> : IResult
         Problem = problem;
     }
 
-    internal static CollectionResult<T> Create(bool isSuccess, T[]? collection, int pageNumber, int pageSize, int totalItems, Problem? problem = null)
+    internal static CollectionResult<T> CreateSuccess(T[]? collection, int pageNumber, int pageSize, int totalItems)
     {
-        return new CollectionResult<T>(isSuccess, collection, pageNumber, pageSize, totalItems, problem);
+        return new CollectionResult<T>(true, collection, pageNumber, pageSize, totalItems, null);
+    }
+
+    internal static CollectionResult<T> CreateFailed(Problem problem, T[]? collection = null)
+    {
+        return new CollectionResult<T>(false, collection, 0, 0, 0, problem);
     }
 
     [JsonPropertyName("isSuccess")]
@@ -170,7 +175,7 @@ public partial struct CollectionResult<T> : IResult
     /// </summary>
     public static CollectionResult<T> Empty()
     {
-        return Create(true, [], 0, 0, 0);
+        return CreateSuccess([], 0, 0, 0);
     }
 
     #endregion

--- a/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
@@ -145,18 +145,18 @@ public partial struct CollectionResult<T> : IResult
             : Problem.InvalidFieldError(fieldName);
     }
 
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string message)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(message);
+            Problem.AddValidationError(message);
     }
 
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string key, string value)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(key, value);
+            Problem.AddValidationError(key, value);
     }
 
     #endregion

--- a/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResult.cs
@@ -39,6 +39,7 @@ public partial struct CollectionResult<T> : IResult
         return new CollectionResult<T>(false, collection, 0, 0, 0, problem);
     }
 
+    [JsonInclude]
     [JsonPropertyName("isSuccess")]
     [JsonPropertyOrder(1)]
     [MemberNotNullWhen(true, nameof(Collection))]
@@ -69,11 +70,13 @@ public partial struct CollectionResult<T> : IResult
     [JsonPropertyOrder(6)]
     public int TotalPages { get; set; }
 
-    private Problem? _problem;
-
+    [JsonInclude]
     [JsonPropertyName("problem")]
     [JsonPropertyOrder(7)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    private Problem? _problem;
+
+    [JsonIgnore]
     public Problem? Problem
     {
         get

--- a/ManagedCode.Communication/CollectionResultT/CollectionResultT.Fail.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResultT.Fail.cs
@@ -10,55 +10,55 @@ public partial struct CollectionResult<T>
 {
     public static CollectionResult<T> Fail()
     {
-        return Create(false, default, 0, 0, 0);
+        return CreateFailed(Problem.GenericError());
     }
 
     public static CollectionResult<T> Fail(IEnumerable<T> value)
     {
-        return Create(false, value.ToArray(), 0, 0, 0);
+        return CreateFailed(Problem.GenericError(), value.ToArray());
     }
 
     public static CollectionResult<T> Fail(T[] value)
     {
-        return Create(false, value, 0, 0, 0);
+        return CreateFailed(Problem.GenericError(), value);
     }
 
     public static CollectionResult<T> Fail(Problem problem)
     {
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> Fail(string title)
     {
         var problem = Problem.Create(title, title, (int)HttpStatusCode.InternalServerError);
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> Fail(string title, string detail)
     {
         var problem = Problem.Create(title, detail);
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> Fail(string title, string detail, HttpStatusCode status)
     {
         var problem = Problem.Create(title, detail, (int)status);
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> Fail(Exception exception)
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
+        return CreateFailed(Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
     }
 
     public static CollectionResult<T> Fail(Exception exception, HttpStatusCode status)
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(exception, (int)status));
+        return CreateFailed(Problem.Create(exception, (int)status));
     }
 
     public static CollectionResult<T> FailValidation(params (string field, string message)[] errors)
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Validation(errors));
+        return CreateFailed(Problem.Validation(errors));
     }
 
     public static CollectionResult<T> FailBadRequest()
@@ -68,7 +68,7 @@ public partial struct CollectionResult<T>
             ProblemConstants.Messages.BadRequest,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailBadRequest(string detail)
@@ -78,7 +78,7 @@ public partial struct CollectionResult<T>
             detail,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailUnauthorized()
@@ -88,7 +88,7 @@ public partial struct CollectionResult<T>
             ProblemConstants.Messages.UnauthorizedAccess,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailUnauthorized(string detail)
@@ -98,7 +98,7 @@ public partial struct CollectionResult<T>
             detail,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailForbidden()
@@ -108,7 +108,7 @@ public partial struct CollectionResult<T>
             ProblemConstants.Messages.ForbiddenAccess,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailForbidden(string detail)
@@ -118,7 +118,7 @@ public partial struct CollectionResult<T>
             detail,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailNotFound()
@@ -128,7 +128,7 @@ public partial struct CollectionResult<T>
             ProblemConstants.Messages.ResourceNotFound,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> FailNotFound(string detail)
@@ -138,26 +138,26 @@ public partial struct CollectionResult<T>
             detail,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, default, 0, 0, 0, problem);
+        return CreateFailed(problem);
     }
 
     public static CollectionResult<T> Fail<TEnum>(TEnum errorCode) where TEnum : Enum
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(errorCode));
+        return CreateFailed(Problem.Create(errorCode));
     }
 
     public static CollectionResult<T> Fail<TEnum>(TEnum errorCode, string detail) where TEnum : Enum
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(errorCode, detail));
+        return CreateFailed(Problem.Create(errorCode, detail));
     }
 
     public static CollectionResult<T> Fail<TEnum>(TEnum errorCode, HttpStatusCode status) where TEnum : Enum
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(errorCode, errorCode.ToString(), (int)status));
+        return CreateFailed(Problem.Create(errorCode, errorCode.ToString(), (int)status));
     }
 
     public static CollectionResult<T> Fail<TEnum>(TEnum errorCode, string detail, HttpStatusCode status) where TEnum : Enum
     {
-        return new CollectionResult<T>(false, default, 0, 0, 0, Problem.Create(errorCode, detail, (int)status));
+        return CreateFailed(Problem.Create(errorCode, detail, (int)status));
     }
 }

--- a/ManagedCode.Communication/CollectionResultT/CollectionResultT.Succeed.cs
+++ b/ManagedCode.Communication/CollectionResultT/CollectionResultT.Succeed.cs
@@ -7,22 +7,22 @@ public partial struct CollectionResult<T>
 {
     public static CollectionResult<T> Succeed(T[] value, int pageNumber, int pageSize, int totalItems)
     {
-        return new CollectionResult<T>(true, value, pageNumber, pageSize, totalItems);
+        return CreateSuccess(value, pageNumber, pageSize, totalItems);
     }
 
     public static CollectionResult<T> Succeed(IEnumerable<T> value, int pageNumber, int pageSize, int totalItems)
     {
-        return new CollectionResult<T>(true, value.ToArray(), pageNumber, pageSize, totalItems);
+        return CreateSuccess(value.ToArray(), pageNumber, pageSize, totalItems);
     }
 
     public static CollectionResult<T> Succeed(T[] value)
     {
-        return new CollectionResult<T>(true, value, 1, value.Length, value.Length);
+        return CreateSuccess(value, 1, value.Length, value.Length);
     }
 
     public static CollectionResult<T> Succeed(IEnumerable<T> value)
     {
         var array = value.ToArray();
-        return new CollectionResult<T>(true, array, 1, array.Length, array.Length);
+        return CreateSuccess(array, 1, array.Length, array.Length);
     }
 }

--- a/ManagedCode.Communication/IResultInvalid.cs
+++ b/ManagedCode.Communication/IResultInvalid.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ManagedCode.Communication;
 
 /// <summary>
@@ -15,6 +17,7 @@ public interface IResultInvalid
     ///     Adds an invalid message to the result.
     /// </summary>
     /// <param name="message">The invalid message to add.</param>
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     void AddInvalidMessage(string message);
 
     /// <summary>
@@ -22,5 +25,6 @@ public interface IResultInvalid
     /// </summary>
     /// <param name="key">The key of the invalid message.</param>
     /// <param name="value">The value of the invalid message.</param>
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     void AddInvalidMessage(string key, string value);
 }

--- a/ManagedCode.Communication/IResultInvalid.cs
+++ b/ManagedCode.Communication/IResultInvalid.cs
@@ -17,7 +17,7 @@ public interface IResultInvalid
     ///     Adds an invalid message to the result.
     /// </summary>
     /// <param name="message">The invalid message to add.</param>
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     void AddInvalidMessage(string message);
 
     /// <summary>
@@ -25,6 +25,6 @@ public interface IResultInvalid
     /// </summary>
     /// <param name="key">The key of the invalid message.</param>
     /// <param name="value">The value of the invalid message.</param>
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     void AddInvalidMessage(string key, string value);
 }

--- a/ManagedCode.Communication/IResultProblem.cs
+++ b/ManagedCode.Communication/IResultProblem.cs
@@ -8,9 +8,9 @@ namespace ManagedCode.Communication;
 public interface IResultProblem
 {
     /// <summary>
-    ///     Gets or sets the problem details.
+    ///     Gets the problem details.
     /// </summary>
-    Problem? Problem { get; set; }
+    Problem? Problem { get; }
 
     /// <summary>
     ///     Determines whether the result has a problem.

--- a/ManagedCode.Communication/ManagedCode.Communication.csproj
+++ b/ManagedCode.Communication/ManagedCode.Communication.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8"/>
     </ItemGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="ManagedCode.Communication.AspNetCore"/>
         <InternalsVisibleTo Include="ManagedCode.Communication.Orleans"/>
     </ItemGroup>
 

--- a/ManagedCode.Communication/Problem/Problem.Extensions.cs
+++ b/ManagedCode.Communication/Problem/Problem.Extensions.cs
@@ -486,6 +486,48 @@ public partial class Problem
         return errors;
     }
 
+    public void AddInvalidMessage(string message)
+    {
+        const string key = ProblemConstants.ValidationFields.General;
+
+        Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
+        if (Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
+        {
+            if (!errors.TryGetValue(key, out List<string>? list))
+            {
+                errors[key] = list = new();
+            }
+
+            list.Add(message);
+        }
+    }
+
+    public void AddInvalidMessage(string key, string value)
+    {
+        Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
+        if (Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
+        {
+            if (!errors.TryGetValue(key, out List<string>? list))
+            {
+                errors[key] = list = new();
+            }
+
+            list.Add(value);
+        }
+    }
+
+    public bool InvalidField(string fieldName)
+    {
+        var errors = GetValidationErrors();
+        return errors?.ContainsKey(fieldName) ?? false;
+    }
+
+    public string InvalidFieldError(string fieldName)
+    {
+        var errors = GetValidationErrors();
+        return errors?.TryGetValue(fieldName, out var fieldErrors) == true ? string.Join(", ", fieldErrors) : string.Empty;
+    }
+
     /// <summary>
     ///     Creates a copy of this Problem with the specified extensions added.
     /// </summary>

--- a/ManagedCode.Communication/Problem/Problem.Extensions.cs
+++ b/ManagedCode.Communication/Problem/Problem.Extensions.cs
@@ -470,7 +470,13 @@ public partial class Problem
 
         fieldErrors.Add(message);
     }
-    
+
+    public void AddValidationError(string message)
+    {
+        const string field = ProblemConstants.ValidationFields.General;
+        AddValidationError(field, message);
+    }
+
     /// <summary>
     ///     Gets or creates validation errors dictionary.
     /// </summary>
@@ -484,36 +490,6 @@ public partial class Problem
         }
         
         return errors;
-    }
-
-    public void AddInvalidMessage(string message)
-    {
-        const string key = ProblemConstants.ValidationFields.General;
-
-        Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.TryGetValue(key, out List<string>? list))
-            {
-                errors[key] = list = new();
-            }
-
-            list.Add(message);
-        }
-    }
-
-    public void AddInvalidMessage(string key, string value)
-    {
-        Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.TryGetValue(key, out List<string>? list))
-            {
-                errors[key] = list = new();
-            }
-
-            list.Add(value);
-        }
     }
 
     public bool InvalidField(string fieldName)

--- a/ManagedCode.Communication/Problem/Problem.cs
+++ b/ManagedCode.Communication/Problem/Problem.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using ManagedCode.Communication.Constants;
 
 namespace ManagedCode.Communication;
 

--- a/ManagedCode.Communication/Problem/Problem.cs
+++ b/ManagedCode.Communication/Problem/Problem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ManagedCode.Communication.Constants;
 
 namespace ManagedCode.Communication;
 

--- a/ManagedCode.Communication/Result/Result.Fail.cs
+++ b/ManagedCode.Communication/Result/Result.Fail.cs
@@ -204,7 +204,7 @@ public partial struct Result
 
     /// <summary>
     ///     Creates a failed result from a custom error enum with detail and specific HTTP status.
-    /// </summary>і
+    /// </summary>
     public static Result Fail<TEnum>(TEnum errorCode, string detail, HttpStatusCode status) where TEnum : Enum
     {
         return CreateFailed(Problem.Create(errorCode, detail, (int)status));

--- a/ManagedCode.Communication/Result/Result.Fail.cs
+++ b/ManagedCode.Communication/Result/Result.Fail.cs
@@ -11,7 +11,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail()
     {
-        return Create(false);
+        return CreateFailed(Problem.GenericError());
     }
 
     /// <summary>
@@ -19,7 +19,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail(Problem problem)
     {
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
 
@@ -29,7 +29,7 @@ public partial struct Result
     public static Result Fail(string title)
     {
         var problem = Problem.Create(title, title, HttpStatusCode.InternalServerError);
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public partial struct Result
     public static Result Fail(string title, string detail)
     {
         var problem = Problem.Create(title, detail, HttpStatusCode.InternalServerError);
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public partial struct Result
     public static Result Fail(string title, string detail, HttpStatusCode status)
     {
         var problem = Problem.Create(title, detail, (int)status);
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail(Exception exception)
     {
-        return Create(false, Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
+        return CreateFailed(Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail(Exception exception, HttpStatusCode status)
     {
-        return Create(false, Problem.Create(exception, (int)status));
+        return CreateFailed(Problem.Create(exception, (int)status));
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ public partial struct Result
     /// </summary>
     public static Result FailValidation(params (string field, string message)[] errors)
     {
-        return new Result(false, Problem.Validation(errors));
+        return CreateFailed(Problem.Validation(errors));
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public partial struct Result
             ProblemConstants.Messages.BadRequest,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public partial struct Result
             detail,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ public partial struct Result
             ProblemConstants.Messages.UnauthorizedAccess,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -123,7 +123,7 @@ public partial struct Result
             detail,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -136,7 +136,7 @@ public partial struct Result
             ProblemConstants.Messages.ForbiddenAccess,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -149,7 +149,7 @@ public partial struct Result
             detail,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -162,7 +162,7 @@ public partial struct Result
             ProblemConstants.Messages.ResourceNotFound,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -175,7 +175,7 @@ public partial struct Result
             detail,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail<TEnum>(TEnum errorCode) where TEnum : Enum
     {
-        return Create(false, Problem.Create(errorCode));
+        return CreateFailed(Problem.Create(errorCode));
     }
 
     /// <summary>
@@ -191,7 +191,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail<TEnum>(TEnum errorCode, string detail) where TEnum : Enum
     {
-        return Create(false, Problem.Create(errorCode, detail));
+        return CreateFailed(Problem.Create(errorCode, detail));
     }
 
     /// <summary>
@@ -199,7 +199,7 @@ public partial struct Result
     /// </summary>
     public static Result Fail<TEnum>(TEnum errorCode, HttpStatusCode status) where TEnum : Enum
     {
-        return Create(false, Problem.Create(errorCode, errorCode.ToString(), (int)status));
+        return CreateFailed(Problem.Create(errorCode, errorCode.ToString(), (int)status));
     }
 
     /// <summary>
@@ -207,6 +207,6 @@ public partial struct Result
     /// </summary>і
     public static Result Fail<TEnum>(TEnum errorCode, string detail, HttpStatusCode status) where TEnum : Enum
     {
-        return Create(false, Problem.Create(errorCode, detail, (int)status));
+        return CreateFailed(Problem.Create(errorCode, detail, (int)status));
     }
 }

--- a/ManagedCode.Communication/Result/Result.Invalid.cs
+++ b/ManagedCode.Communication/Result/Result.Invalid.cs
@@ -15,7 +15,7 @@ public partial struct Result
     {
         var problem = Problem.Validation(("message", nameof(Invalid)));
         problem.ErrorCode = code.ToString();
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     public static Result Invalid(string message)
@@ -27,7 +27,7 @@ public partial struct Result
     {
         var problem = Problem.Validation((nameof(message), message));
         problem.ErrorCode = code.ToString();
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     public static Result Invalid(string key, string value)
@@ -39,7 +39,7 @@ public partial struct Result
     {
         var problem = Problem.Validation((key, value));
         problem.ErrorCode = code.ToString();
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
     public static Result Invalid(Dictionary<string, string> values)
@@ -53,7 +53,7 @@ public partial struct Result
         var problem = Problem.Validation(values.Select(kvp => (kvp.Key, kvp.Value))
             .ToArray());
         problem.ErrorCode = code.ToString();
-        return Create(false, problem);
+        return CreateFailed(problem);
     }
 
 

--- a/ManagedCode.Communication/Result/Result.Succeed.cs
+++ b/ManagedCode.Communication/Result/Result.Succeed.cs
@@ -6,7 +6,7 @@ public partial struct Result
 {
     public static Result Succeed()
     {
-        return Create(true);
+        return CreateSuccess();
     }
 
     public static Result<T> Succeed<T>(T value)

--- a/ManagedCode.Communication/Result/Result.cs
+++ b/ManagedCode.Communication/Result/Result.cs
@@ -52,7 +52,7 @@ public partial struct Result : IResult
     ///     Gets a value indicating whether the operation failed.
     /// </summary>
     [JsonIgnore]
-    public bool IsFailed => !IsSuccess || HasProblem;
+    public bool IsFailed => !IsSuccess;
 
     private Problem? _problem;
 
@@ -80,7 +80,7 @@ public partial struct Result : IResult
     /// </summary>
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(Problem))]
-    public bool HasProblem => Problem != null;
+    public bool HasProblem => !IsSuccess;
 
 
     /// <summary>
@@ -94,9 +94,10 @@ public partial struct Result : IResult
     /// </summary>
     public bool ThrowIfFail()
     {
-        if (HasProblem)
+        var problem = Problem;
+        if (problem is not null)
         {
-            throw Problem;
+            throw problem;
         }
 
         return false;

--- a/ManagedCode.Communication/Result/Result.cs
+++ b/ManagedCode.Communication/Result/Result.cs
@@ -137,18 +137,18 @@ public partial struct Result : IResult
             : Problem.InvalidFieldError(fieldName);
     }
 
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string message)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(message);
+            Problem.AddValidationError(message);
     }
 
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string key, string value)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(key, value);
+            Problem.AddValidationError(key, value);
     }
 
     #endregion

--- a/ManagedCode.Communication/Result/Result.cs
+++ b/ManagedCode.Communication/Result/Result.cs
@@ -127,52 +127,28 @@ public partial struct Result : IResult
 
     public bool InvalidField(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.ContainsKey(fieldName) ?? false;
+        return !IsSuccess && Problem.InvalidField(fieldName);
     }
 
     public string InvalidFieldError(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.TryGetValue(fieldName, out var fieldErrors) == true ? string.Join(", ", fieldErrors) : string.Empty;
+        return IsSuccess
+            ? string.Empty
+            : Problem.InvalidFieldError(fieldName);
     }
 
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string message)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(ProblemConstants.ValidationFields.General))
-            {
-                errors[ProblemConstants.ValidationFields.General] = new List<string>();
-            }
-
-            errors[ProblemConstants.ValidationFields.General]
-                .Add(message);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(message);
     }
 
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string key, string value)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(key))
-            {
-                errors[key] = new List<string>();
-            }
-
-            errors[key]
-                .Add(value);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(key, value);
     }
 
     #endregion

--- a/ManagedCode.Communication/Result/Result.cs
+++ b/ManagedCode.Communication/Result/Result.cs
@@ -43,6 +43,7 @@ public partial struct Result : IResult
     /// <summary>
     ///     Gets or sets a value indicating whether the operation was successful.
     /// </summary>
+    [JsonInclude]
     [JsonPropertyName("isSuccess")]
     [JsonPropertyOrder(1)]
     [MemberNotNullWhen(false, nameof(Problem))]
@@ -54,14 +55,16 @@ public partial struct Result : IResult
     [JsonIgnore]
     public bool IsFailed => !IsSuccess;
 
+    [JsonInclude]
+    [JsonPropertyName("problem")]
+    [JsonPropertyOrder(2)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     private Problem? _problem;
 
     /// <summary>
     ///     Gets or sets the problem that occurred during the operation.
     /// </summary>
-    [JsonPropertyName("problem")]
-    [JsonPropertyOrder(2)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public Problem? Problem
     {
         get

--- a/ManagedCode.Communication/ResultT/Result.cs
+++ b/ManagedCode.Communication/ResultT/Result.cs
@@ -27,6 +27,14 @@ public partial struct Result<T> : IResult<T>
     }
 
     /// <summary>
+    ///     Initializes a new instance of the Result struct with an exception.
+    /// </summary>
+    private Result(Exception exception) : this(false, default, Problem.Create(exception))
+    {
+
+    }
+
+    /// <summary>
     ///     Creates a successful Result with the specified value.
     /// </summary>
     internal static Result<T> CreateSuccess(T value)

--- a/ManagedCode.Communication/ResultT/Result.cs
+++ b/ManagedCode.Communication/ResultT/Result.cs
@@ -73,6 +73,7 @@ public partial struct Result<T> : IResult<T>
     /// <summary>
     ///     Gets a value indicating whether the result is a success.
     /// </summary>
+    [JsonInclude]
     [MemberNotNullWhen(true, nameof(Value))]
     [MemberNotNullWhen(false, nameof(Problem))]
     public bool IsSuccess { get; private init; }
@@ -96,15 +97,16 @@ public partial struct Result<T> : IResult<T>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public T? Value { get; set; }
 
-
+    [JsonInclude]
+    [JsonPropertyName("problem")]
+    [JsonPropertyOrder(3)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     private Problem? _problem;
 
     /// <summary>
     ///     Gets or sets the problem that occurred during the operation.
     /// </summary>
-    [JsonPropertyName("problem")]
-    [JsonPropertyOrder(3)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public Problem? Problem
     {
         get

--- a/ManagedCode.Communication/ResultT/Result.cs
+++ b/ManagedCode.Communication/ResultT/Result.cs
@@ -153,21 +153,21 @@ public partial struct Result<T> : IResult<T>
     /// <summary>
     ///     Adds an invalid message to the result.
     /// </summary>
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string message)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(message);
+            Problem.AddValidationError(message);
     }
 
     /// <summary>
     ///     Adds an invalid message with a specific key to the result.
     /// </summary>
-    [Obsolete("Use Problem.AddInvalidMessage instead")]
+    [Obsolete("Use Problem.AddValidationError instead")]
     public void AddInvalidMessage(string key, string value)
     {
         if (!IsSuccess)
-            Problem.AddInvalidMessage(key, value);
+            Problem.AddValidationError(key, value);
     }
 
     public bool InvalidField(string fieldName)

--- a/ManagedCode.Communication/ResultT/Result.cs
+++ b/ManagedCode.Communication/ResultT/Result.cs
@@ -153,57 +153,33 @@ public partial struct Result<T> : IResult<T>
     /// <summary>
     ///     Adds an invalid message to the result.
     /// </summary>
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string message)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(ProblemConstants.ValidationFields.General))
-            {
-                errors[ProblemConstants.ValidationFields.General] = new List<string>();
-            }
-
-            errors[ProblemConstants.ValidationFields.General]
-                .Add(message);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(message);
     }
 
     /// <summary>
     ///     Adds an invalid message with a specific key to the result.
     /// </summary>
+    [Obsolete("Use Problem.AddInvalidMessage instead")]
     public void AddInvalidMessage(string key, string value)
     {
-        if (IsSuccess) throw new InvalidOperationException("Cannot add invalid message to a successful result");
-
-        var problem = Problem;
-
-        problem.Extensions[ProblemConstants.ExtensionKeys.Errors] ??= new Dictionary<string, List<string>>();
-        if (problem.Extensions[ProblemConstants.ExtensionKeys.Errors] is Dictionary<string, List<string>> errors)
-        {
-            if (!errors.ContainsKey(key))
-            {
-                errors[key] = new List<string>();
-            }
-
-            errors[key]
-                .Add(value);
-        }
+        if (!IsSuccess)
+            Problem.AddInvalidMessage(key, value);
     }
 
     public bool InvalidField(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.ContainsKey(fieldName) ?? false;
+        return !IsSuccess && Problem.InvalidField(fieldName);
     }
 
     public string InvalidFieldError(string fieldName)
     {
-        var errors = Problem?.GetValidationErrors();
-        return errors?.TryGetValue(fieldName, out var fieldErrors) == true ? string.Join(", ", fieldErrors) : string.Empty;
+        return IsSuccess
+            ? string.Empty
+            : Problem.InvalidFieldError(fieldName);
     }
 
     public Dictionary<string, List<string>>? InvalidObject => Problem?.GetValidationErrors();

--- a/ManagedCode.Communication/ResultT/Result.cs
+++ b/ManagedCode.Communication/ResultT/Result.cs
@@ -48,9 +48,10 @@ public partial struct Result<T> : IResult<T>
     /// </summary>
     public bool ThrowIfFail()
     {
-        if (HasProblem)
+        var problem = Problem;
+        if (problem is not null)
         {
-            throw Problem;
+            throw problem;
         }
 
         return false;
@@ -87,7 +88,7 @@ public partial struct Result<T> : IResult<T>
     /// </summary>
     [JsonIgnore]
     [MemberNotNullWhen(false, nameof(Value))]
-    public bool IsFailed => !IsSuccess || HasProblem;
+    public bool IsFailed => !IsSuccess;
 
     /// <summary>
     ///     Gets or sets the value of the result.
@@ -121,7 +122,7 @@ public partial struct Result<T> : IResult<T>
     /// </summary>
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(Problem))]
-    public bool HasProblem => Problem is not null;
+    public bool HasProblem => !IsSuccess;
 
     /// <summary>
     ///     Get the Problem assigned to the result without falling back to a generic error if no problem is assigned.

--- a/ManagedCode.Communication/ResultT/ResultT.Fail.cs
+++ b/ManagedCode.Communication/ResultT/ResultT.Fail.cs
@@ -15,7 +15,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail()
     {
-        return Create(false, default);
+        return CreateFailed(Problem.GenericError());
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail(T value)
     {
-        return Create(false, value);
+        return CreateFailed(Problem.GenericError(), value);
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail(Problem problem)
     {
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
 
@@ -41,7 +41,7 @@ public partial struct Result<T>
     public static Result<T> Fail(string title)
     {
         var problem = Problem.Create(title, title, (int)HttpStatusCode.InternalServerError);
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public partial struct Result<T>
     public static Result<T> Fail(string title, string detail)
     {
         var problem = Problem.Create(title, detail);
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public partial struct Result<T>
     public static Result<T> Fail(string title, string detail, HttpStatusCode status)
     {
         var problem = Problem.Create(title, detail, (int)status);
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail(Exception exception)
     {
-        return new Result<T>(false, default, Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
+        return CreateFailed(Problem.Create(exception, (int)HttpStatusCode.InternalServerError));
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail(Exception exception, HttpStatusCode status)
     {
-        return new Result<T>(false, default, Problem.Create(exception, (int)status));
+        return CreateFailed(Problem.Create(exception, (int)status));
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> FailValidation(params (string field, string message)[] errors)
     {
-        return new Result<T>(false, default, Problem.Validation(errors));
+        return CreateFailed(Problem.Validation(errors));
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public partial struct Result<T>
             ProblemConstants.Messages.BadRequest,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -109,7 +109,7 @@ public partial struct Result<T>
             detail,
             (int)HttpStatusCode.BadRequest);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public partial struct Result<T>
             ProblemConstants.Messages.UnauthorizedAccess,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -135,7 +135,7 @@ public partial struct Result<T>
             detail,
             (int)HttpStatusCode.Unauthorized);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -148,7 +148,7 @@ public partial struct Result<T>
             ProblemConstants.Messages.ForbiddenAccess,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ public partial struct Result<T>
             detail,
             (int)HttpStatusCode.Forbidden);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -174,7 +174,7 @@ public partial struct Result<T>
             ProblemConstants.Messages.ResourceNotFound,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -187,7 +187,7 @@ public partial struct Result<T>
             detail,
             (int)HttpStatusCode.NotFound);
 
-        return Create(false, default, problem);
+        return CreateFailed(problem);
     }
 
     /// <summary>
@@ -195,7 +195,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail<TEnum>(TEnum errorCode) where TEnum : Enum
     {
-        return new Result<T>(false, default, Problem.Create(errorCode));
+        return CreateFailed(Problem.Create(errorCode));
     }
 
     /// <summary>
@@ -203,7 +203,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail<TEnum>(TEnum errorCode, string detail) where TEnum : Enum
     {
-        return new Result<T>(false, default, Problem.Create(errorCode, detail));
+        return CreateFailed(Problem.Create(errorCode, detail));
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail<TEnum>(TEnum errorCode, HttpStatusCode status) where TEnum : Enum
     {
-        return new Result<T>(false, default, Problem.Create(errorCode, errorCode.ToString(), (int)status));
+        return CreateFailed(Problem.Create(errorCode, errorCode.ToString(), (int)status));
     }
 
     /// <summary>
@@ -219,6 +219,6 @@ public partial struct Result<T>
     /// </summary>
     public static Result<T> Fail<TEnum>(TEnum errorCode, string detail, HttpStatusCode status) where TEnum : Enum
     {
-        return new Result<T>(false, default, Problem.Create(errorCode, detail, (int)status));
+        return CreateFailed(Problem.Create(errorCode, detail, (int)status));
     }
 }

--- a/ManagedCode.Communication/ResultT/ResultT.Succeed.cs
+++ b/ManagedCode.Communication/ResultT/ResultT.Succeed.cs
@@ -6,7 +6,7 @@ public partial struct Result<T>
 {
     public static Result<T> Succeed(T value)
     {
-        return Create(true, value);
+        return CreateSuccess(value);
     }
 
     public static Result<T> Succeed(Action<T> action)


### PR DESCRIPTION
## Description
Successful results and problematic results should be mutually exclusive. Failed results should always have a problem by design, and successful results should not. This PR ensures `Problem` can never be null when `IsSuccess` is `false`. Additionally, it cleans up cases where a result could be both successful and failed.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
<!-- List the specific changes made in this PR -->

- Changes mentioned here were applied to `Result`, Result<T>` and `CollectionResult<T>` types. I'll just refer to `Result` for simplicity.
- Changed `Result` constructor from `internal` to `private`.
- Replaced `internal` `Create` methods with a `CreateSuccess` and `CreateFailed` method to help enforce parameters in either case.
- All creation methods (ie. `Result.Fail(...)`) now use these new methods, whereas previously some cases directly used the constructor.
- (Breaking) Changed `IsSuccess` set method from `init` to `private init`.
- (Breaking) Changed `Problem` set method from `set` to `private init`.
- (Breaking) Removed `IResultProblem.Problem.set` property setter.
- Implemented a backing field for the `Problem` property. `Problem.get` checks if the backing field is null and success is false, and assigns a generic error in this case. This will only occur if the user uses the default result value, ie. `Result r = default;`. Also note that the Json-related attributes on `Problem` property have been moved to the backing field, and the property now has a `[JsonIgnore]` attribute.
- Added `[JsonInclude]` attributes to new private data to preserve deserialization.
- Changed behavior of `AddInvalidMessage` methods to throw an `InvalidOperationException` when invoked on a successful result.
- Fixed several tests that asserted `HasProblem.Should().BeFalse()` for failed results. These tests used `Fail(...)` overloads that previously did not assign a `Problem`, hence the assertion. These tests now assert `Should().BeTrue()`.

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
<!-- Mark completed items with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
<!-- Link any related issues here -->

Closes #32 
Closes #35 

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information that reviewers should know -->

Since `IsSuccess` & `Problem` properties can no longer be publicly set, users can no longer construct a result like so: `new Result { IsSuccess = false, Problem = ... };`.